### PR TITLE
Ocultar menu en resolucion para tabletas

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/7db2da0ce59c4610abfda6c55e29e99d)](https://www.codacy.com/app/vazeri/ProtoWeb?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Ahorratec/ProtoWeb&amp;utm_campaign=Badge_Grade)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 ___
-Página de presentación de proyecto de Ahorratec México, previo al FIT 2017
+Página de presentación de proyecto de Ahorratec México, previo al FIT 2017.
 
 Una aplicación para procesar, logear, visualizar, energía, temperatura y otras variables ambientales.
 Es una herramienta de software-libre para el monitoreo de energía electrica a partir del proyecto [OpenEnergyMonitor project](http://openenergymonitor.org), localizada para latino america.

--- a/css/Hoja_de_Estilo.css
+++ b/css/Hoja_de_Estilo.css
@@ -723,18 +723,22 @@ ul.templatemo-project-gallery  li  a img:hover {
     padding-top: 9px;
     padding-bottom: 9px;
   }
-  #Ahorratec-Centro {
-        float: left; 
-    }
   .templatemo-team{
     background-size: 100% 100%;
     }
   .templatemo-footer {
   background-size: 100% 100%;
-    } 
+    }
 }
 
-@media (max-width: 768px) {
+@media (min-width: 992px){
+    #Ahorratec-Centro {
+        float: left;
+  }
+
+}
+
+@media (max-width: 992px) {
     .member-thumb .thumb-overlay {
         padding-left: 40%;
        
@@ -745,6 +749,9 @@ ul.templatemo-project-gallery  li  a img:hover {
       }
     #centroTs {
     text-align: center;
+    }
+    #templatemo-nav-bar{
+    display: none;
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -33,7 +33,6 @@
             <div class="container">
                 <div class="navbar navbar-default" role="navigation">
                     <div class="container">
-                        <div class="navbar-header">
                             <!--
                             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
                                 <span class="sr-only">Toggle navigation</span>
@@ -45,8 +44,7 @@
                             <div id="Ahorratec-Centro">
                                 <a href="#inicio"><img src="images/templatemo_logo.png" class="img-responsive" alt="Logo Ahorratec" title="Ahorratec.org" /></a>
                             </div>
-                        </div>
-                        <div class="navbar-collapse collapse" id="templatemo-nav-bar">
+                        <div id="templatemo-nav-bar">
                             <ul class="nav navbar-nav navbar-right" style="margin-top: 20px;">
                                 <li><a href="#templatemo-1">¿QUE ES?</a></li>
                                 <li><a href="#templatemo-2">PROTOTIPO</a></li>


### PR DESCRIPTION
Solución excelente a la resolución del iPad  pero en resolución alrededor de 600 se sube el carrusel favor de revisar en https://juanczd.github.io/ProtoWeb/
@vazeri 

> El menú se oculta al ocupara un renglón mas, esto es en una resolución de 992.