### PR TITLE
fixing image footer

### DIFF
--- a/css/Hoja_de_Estilo.css
+++ b/css/Hoja_de_Estilo.css
@@ -520,6 +520,9 @@ h1, h2, h3, h4, h5, h6, span, p { font-family: 'Open Sans', Arial, Helvetice Neu
 	background-attachment: static;
 	background-color: black;
 	max-width: 100%;
+    background-size: cover;
+    overflow-x: hidden;
+    margin-bottom: 0;
 	
 }
 
@@ -705,7 +708,9 @@ ul.templatemo-project-gallery  li  a img:hover {
     background-size: 100% 100%;
     }
   .templatemo-footer {
-  background-size: 100% 100%;
+      background-size: cover;
+      overflow-x: hidden;
+      margin-bottom: 0;
     }
 }
 


### PR DESCRIPTION
el background del `div` con la clase `.templatemo-footer` tiene el mismo comportamiento que la del slider, es decir se mantiene a lo largo y ancho de la pagina, por lo que  ahora la imagen no pierde las proporciones normales de la misma y no se ve distorcionada